### PR TITLE
Handle fields becoming blank, use recordId as primary key, add inter-table delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ const monitor = new AirtableMonitor(
     baseID: xxx, // Airtable base ID
     apiKey: xxx, // Airtable API token
     tables: ['table_to_monitor'],
+    tableInterval: 1, // Optional (default = 0) : an interval in seconds between calls to Airtable API for each table of a tick to avoid rate limiting.
   },
   event => {
     // event structure :
     // {
+    //   date,
     //   tableName,
     //   fieldName,
     //   previousValue,
@@ -41,4 +43,3 @@ monitor.start(30); // Poll every 30 seconds. Default : 60 seconds
 ## Running tests
 
 `yarn install && yarn test`
-

--- a/build/cjs/utils.js
+++ b/build/cjs/utils.js
@@ -33,8 +33,8 @@ var deepEqual = _interopDefault(require('fast-deep-equal'));
  * - collaborator
  * - formula
  * - rollup
- * @param {*} a left comparison operand
- * @param {*} b right comparison operand
+ * @param {*} a - Left comparison operand.
+ * @param {*} b - Right comparison operand.
  */
 const airtableFieldValuesAreEqual = (a, b) => {
   // If one of the values is falsy and not the other, they're not equal
@@ -61,4 +61,24 @@ const airtableFieldValuesAreEqual = (a, b) => {
   return a === b;
 };
 
+/**
+ * Sequentially performs an async function on every item of an array.
+ * @param {Array} inputArray - The input array.
+ * @param {function} func - Async function that will be executed for each element in the input array.
+ */
+const chainPromises = (inputArray, func) =>
+  inputArray.reduce(
+    (promise, item) => promise.then(() => func(item)),
+    Promise.resolve(),
+  );
+
+/**
+ * Returns a promise that will resolve after the given delay.
+ * @param {number} delay - The number of milliseconds to wait for.
+ */
+const waitFor = delay =>
+  new Promise(resolve => setTimeout(resolve, delay));
+
 exports.airtableFieldValuesAreEqual = airtableFieldValuesAreEqual;
+exports.chainPromises = chainPromises;
+exports.waitFor = waitFor;

--- a/build/umd/airtable-monitor.js
+++ b/build/umd/airtable-monitor.js
@@ -34,8 +34,8 @@
    * - collaborator
    * - formula
    * - rollup
-   * @param {*} a left comparison operand
-   * @param {*} b right comparison operand
+   * @param {*} a - Left comparison operand.
+   * @param {*} b - Right comparison operand.
    */
   const airtableFieldValuesAreEqual = (a, b) => {
     // If one of the values is falsy and not the other, they're not equal
@@ -62,7 +62,31 @@
     return a === b;
   };
 
+  /**
+   * Sequentially performs an async function on every item of an array.
+   * @param {Array} inputArray - The input array.
+   * @param {function} func - Async function that will be executed for each element in the input array.
+   */
+  const chainPromises = (inputArray, func) =>
+    inputArray.reduce(
+      (promise, item) => promise.then(() => func(item)),
+      Promise.resolve(),
+    );
+
+  /**
+   * Returns a promise that will resolve after the given delay.
+   * @param {number} delay - The number of milliseconds to wait for.
+   */
+  const waitFor = delay =>
+    new Promise(resolve => setTimeout(resolve, delay));
+
   class AirTableMonitor {
+    /**
+     * Creates a monitor for one or more table(s) of a given base.
+     * You still need to call start() in order to start watching for changes.
+     * @param {Object} options - Config of the monitor. See the README for possible options.
+     * @param {function} onUpdate - The event handler that will be called upon change.
+     */
     constructor(options = {}, onUpdate = () => {}) {
       if (!options.tables || options.tables.length === 0) {
         throw new Error('Please specify at least one table to monitor.');
@@ -90,8 +114,8 @@
     }
 
     /**
-     * Starts watching the airtable tables for changes
-     * @param {integer} intervalSeconds polling interval in seconds
+     * Starts watching the airtable tables for changes.
+     * @param {integer} intervalSeconds - Polling interval between each tick in seconds.
      */
     start(intervalSeconds = 60) {
       this.interval = setInterval(this.checkForUpdates, intervalSeconds * 1000);
@@ -99,7 +123,7 @@
     }
 
     /**
-     * Stops watching the airtable tables for changes
+     * Stops watching the airtable tables for changes.
      */
     stop() {
       clearInterval(this.interval);
@@ -110,27 +134,33 @@
      * Called automatically at a fixed interval when start() has been called.
      */
     async checkForUpdates() {
-      return Promise.all(
-        this.options.tables.map(tableName =>
-          this.checkUpdatesForTable(tableName),
-        ),
-      );
+      return chainPromises(this.options.tables, tableName => {
+        return this.checkUpdatesForTable(tableName).then(() => {
+          // If set in the options, wait before proceeding to the next table
+          if (this.options.tableInterval) {
+            return waitFor(this.options.tableInterval * 1000);
+          }
+          return null;
+        });
+      });
     }
 
     /**
      * Checks for changes on every record of the given table.
      * Called automatically by checkForUpdates() at a fixed interval when start() has been called.
+     * @param {string} tableName - The name of the table to check for changes.
      */
     async checkUpdatesForTable(tableName) {
       // Boolean telling if we are checking this table for the first time
       let firstPass = false;
       if (!this.previousValues[tableName]) {
-        this.previousValues[tableName] = [];
+        this.previousValues[tableName] = {};
         firstPass = true;
       }
       // Fetch all the records from the table
       const records = await this.airtable.read(tableName);
-      records.forEach((record, index) => {
+      records.forEach(record => {
+        const index = record.id;
         if (!this.previousValues[tableName][index]) {
           this.previousValues[tableName][index] = {};
         }

--- a/build/umd/airtable-monitor.js
+++ b/build/umd/airtable-monitor.js
@@ -131,12 +131,27 @@
       // Fetch all the records from the table
       const records = await this.airtable.read(tableName);
       records.forEach((record, index) => {
+        if (!this.previousValues[tableName][index]) {
+          this.previousValues[tableName][index] = {};
+        }
+        // For each record, build the list of fields to be checked for change
+        // We need to watch both the previous values and the current record
+        // This is due to Airtable API design only returning non-blank fields
+        // If a field became blank, it won't appear in the record but we still need to fire the event
+        const fields = [];
+        if (this.previousValues[tableName][index]) {
+          Object.keys(this.previousValues[tableName][index]).forEach(field => {
+            if (!fields.includes(field)) fields.push(field);
+          });
+        }
+        Object.keys(record.fields).forEach(field => {
+          if (!fields.includes(field)) fields.push(field);
+        });
+
         // For each field of each record, compare the current value to the previous value
-        Object.keys(record.fields).forEach(fieldName => {
+        fields.forEach(fieldName => {
           const newValue = record.fields[fieldName];
-          if (!this.previousValues[tableName][index]) {
-            this.previousValues[tableName][index] = {};
-          }
+
           if (firstPass) {
             // First time we fetch the values, all the previous values will be undefined
             // We don't want to fire events in that case, so just store the current values
@@ -147,6 +162,7 @@
           if (!airtableFieldValuesAreEqual(newValue, previousValue)) {
             // There was a change in value, so fire the event handler
             this.onUpdate({
+              date: new Date().toISOString(),
               tableName,
               fieldName,
               previousValue,

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,8 @@ import deepEqual from 'fast-deep-equal';
  * - collaborator
  * - formula
  * - rollup
- * @param {*} a left comparison operand
- * @param {*} b right comparison operand
+ * @param {*} a - Left comparison operand.
+ * @param {*} b - Right comparison operand.
  */
 export const airtableFieldValuesAreEqual = (a, b) => {
   // If one of the values is falsy and not the other, they're not equal
@@ -54,3 +54,21 @@ export const airtableFieldValuesAreEqual = (a, b) => {
   // Behaves as a simple === for non-arrays
   return a === b;
 };
+
+/**
+ * Sequentially performs an async function on every item of an array.
+ * @param {Array} inputArray - The input array.
+ * @param {function} func - Async function that will be executed for each element in the input array.
+ */
+export const chainPromises = (inputArray, func) =>
+  inputArray.reduce(
+    (promise, item) => promise.then(() => func(item)),
+    Promise.resolve(),
+  );
+
+/**
+ * Returns a promise that will resolve after the given delay.
+ * @param {number} delay - The number of milliseconds to wait for.
+ */
+export const waitFor = delay =>
+  new Promise(resolve => setTimeout(resolve, delay));


### PR DESCRIPTION
- Add date to fired events
- Fire an event when a field becomes blank
- Use the record ID as the primary key instead of the response array index
- Add an optional delay between tables to avoid rate limiting